### PR TITLE
Run `node@4.1.1` on Heroku

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -2,4 +2,18 @@
 
 set -e
 
+# Set up node
 npm install
+
+# Set up deploys
+if heroku join --app hound-mdast-staging &> /dev/null; then
+  git remote add staging git@heroku.com:hound-mdast-staging.git || true
+else
+  printf 'Ask for access to the "hound-mdast-staging" Heroku app\n'
+fi
+
+if heroku join --app hound-mdast-production &> /dev/null; then
+  git remote add production git@heroku.com:hound-mdast-production.git || true
+else
+  printf 'Ask for access to the "hound-mdast-production" Heroku app\n'
+fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "hound-mdast",
   "version": "0.0.1",
+  "engines": {
+    "node": "4.1.1"
+  },
   "description": "mdast-lint service for Hound",
   "main": "index.js",
   "scripts": {
@@ -27,7 +30,7 @@
   "dependencies": {
     "mdast": "^2.1.0",
     "mdast-lint": "^1.1.1",
-    "node-resque": "^1.0.2",
+    "node-resque": "^1.1.1",
     "redis": "^2.1.0",
     "rsvp": "^3.1.0"
   },


### PR DESCRIPTION
https://github.com/nodejs/node-v0.x-archive/issues/5108

Given the appearance of:

```
(node) warning: possible EventEmitter memory leak detected. 12 end
listeners added. Use emitter.setMaxListeners() to increase limit.
```

in the logs, we should upgrade and lock our Node engine to a more stable
branch.

Luckily, [Heroku supports releases in the 4.x series][heroku].

Also upgrades to the latest version of `node-resque`, which could
contain a fix for [taskrabbit/node-resque#83][#83].

[heroku]: https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version
[#83]: https://github.com/taskrabbit/node-resque/issues/83