### PR TITLE
Support .mdastrc structure

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -3,11 +3,11 @@ var mdastLint = require("mdast-lint");
 
 function parseConfig(config) {
   if (!config) {
-    config = "{}";
+    config = "{ 'plugins': { 'lint': {} } }";
   }
 
   try {
-    return JSON.parse(config);
+    return JSON.parse(config).plugins.lint;
   } catch (exception) {
     console.log("Invalid mdast-lint configuration:");
     console.log(config);

--- a/tests/helpers/config.js
+++ b/tests/helpers/config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  configContentFor: function(config) {
+    var fullMdastConfig = {
+      "plugins": {
+        "lint": config
+      }
+    };
+    return JSON.stringify(fullMdastConfig);
+  }
+};

--- a/tests/integration-test.js
+++ b/tests/integration-test.js
@@ -3,6 +3,7 @@ var RSVP = require("rsvp");
 var Linter = require("../lib/linter");
 var Queue = require("../lib/queue");
 var lastJob = require("./helpers/redis").lastJob;
+var configContentFor = require("./helpers/config").configContentFor;
 
 QUnit.module("Integration");
 
@@ -19,7 +20,7 @@ asyncTest("Linter communicates over resque", function() {
   var linter = new Linter(outbound);
   var inboundJob = {
     content: "# Hello\n",
-    config: JSON.stringify({ "heading-style": "setext" }),
+    config: configContentFor({ "heading-style": "setext" }),
     filename: "filename",
     commit_sha: "commit_sha",
     pull_request_number: "pull_request_number",

--- a/tests/linter-test.js
+++ b/tests/linter-test.js
@@ -1,11 +1,12 @@
 var Linter = require("../lib/linter");
+var configContentFor = require("./helpers/config").configContentFor;
 
 QUnit.module("Linter");
 
 test("mdast linting", function() {
   var payload = {
     content: "# Hello\n",
-    config: JSON.stringify({ "heading-style": "setext" }),
+    config: configContentFor({ "heading-style": "setext" }),
     filename: "filename",
     commit_sha: "commit_sha",
     pull_request_number: "pull_request_number",


### PR DESCRIPTION
The oringinal implementation was assuming a user's .mdastrc file only had the
config for the mdast-lint plugin. This worked, but it means you could
not use the same file with the `mdast` CLI. This change adds support for
the full structure, so the same file can be used with the CLI tool and
on Hound.

That structure is:


    {
      "plugins": {
        "lint": {
          "rule1": options,
          "rule2": options
        }
      }
    }

https://github.com/wooorm/mdast-lint#configuring-mdast-lint

An example PR on staging: https://github.com/thornco/dumb-ruby/pull/110