### PR TITLE
Update for the mdast -> remark rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Hound mdast
+# Hound remark
 
-[mdast] is Markdown processor powered by plugins. [mdast-lint] is an mdast
+[remark] is Markdown processor powered by plugins. [remark-lint] is an remark
 plugin for linting Markdown style.
 
-`hound-mdast` is a Node service that polls `MdastReviewJob`s from the
-`mdast_review` queue, lints code with `mdast-lint`, then pushes the results to
+`hound-remark` is a Node service that polls `RemarkReviewJob`s from the
+`remark_review` queue, lints code with `remark-lint`, then pushes the results to
 the `high` queue, as `CompletedFileReviewJob`s.
 
-[mdast]: http://mdast.js.org/
-[mdast-lint]: https://github.com/wooorm/mdast-lint
+[remark]: http://remark.js.org/
+[remark-lint]: https://github.com/wooorm/remark-lint
 
 ## Testing locally
 

--- a/index.js
+++ b/index.js
@@ -12,9 +12,9 @@ var linter = new Linter(houndJavascript);
 var worker = new Resque.multiWorker(
   {
     connection: { redis: redis },
-    queues: ["mdast_review"],
+    queues: ["remark_review"],
   }, {
-    "MdastReviewJob": function(payload, callback) {
+    "RemarkReviewJob": function(payload, callback) {
       linter.lint(payload).finally(callback);
     }
   }

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,5 +1,5 @@
-var mdast = require("mdast");
-var mdastLint = require("mdast-lint");
+var remark = require("remark");
+var remarkLint = require("remark-lint");
 var Config = require("./config");
 
 function Linter(houndJavascript) {
@@ -10,7 +10,7 @@ Linter.prototype.lint = function(payload) {
   var config = new Config(payload.config);
 
   if (config.isValid()) {
-    var processor = mdast().use(mdastLint, config.parse());
+    var processor = remark().use(remarkLint, config.parse());
 
     var results;
     processor.process(payload.content, function(_error, file) {
@@ -32,7 +32,7 @@ Linter.prototype.lint = function(payload) {
     return this.houndJavascript.reportInvalidConfig({
       pull_request_number: payload.pull_request_number,
       commit_sha: payload.commit_sha,
-      linter_name: "mdast",
+      linter_name: "remark",
     });
   }
 };

--- a/lib/test-queue.js
+++ b/lib/test-queue.js
@@ -3,8 +3,8 @@ var Queue = require("hound-javascript/lib/queue");
 module.exports = function(redis) {
   var inbound = new Queue({
     redis: redis,
-    queueName: "mdast_review",
-    jobName: "MdasatReviewJob",
+    queueName: "remark_review",
+    jobName: "RemarkReviewJob",
   });
 
   inbound.enqueue({

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "hound-mdast",
+  "name": "hound-remark",
   "version": "0.0.1",
   "engines": {
     "node": "4.1.1"
   },
-  "description": "mdast-lint service for Hound",
+  "description": "remark-lint service for Hound",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
@@ -29,8 +29,8 @@
   "homepage": "https://github.com/thoughtbot/hound-mdast#readme",
   "dependencies": {
     "hound-javascript": "0.0.2",
-    "mdast": "^2.1.0",
-    "mdast-lint": "^1.1.1",
+    "remark": "^3.2.2",
+    "remark-lint": "^2.2.1",
     "node-resque": "^1.1.1",
     "redis": "^2.1.0",
     "rsvp": "^3.1.0"

--- a/tests/config-test.js
+++ b/tests/config-test.js
@@ -3,7 +3,7 @@ var configContentFor = require("./helpers/config").configContentFor;
 
 QUnit.module("Config");
 
-test("Parsing an MDast config file", function() {
+test("Parsing a Remark config file", function() {
   var config = new Config(
     configContentFor({ "heading-style": "setext" })
   );

--- a/tests/helpers/config.js
+++ b/tests/helpers/config.js
@@ -1,10 +1,10 @@
 module.exports = {
   configContentFor: function(config) {
-    var fullMdastConfig = {
+    var fullRemarkConfig = {
       "plugins": {
         "lint": config
       }
     };
-    return JSON.stringify(fullMdastConfig);
+    return JSON.stringify(fullRemarkConfig);
   }
 };

--- a/tests/linter-test.js
+++ b/tests/linter-test.js
@@ -11,7 +11,7 @@ RSVP.on("error", function(error) {
   throw new Error(error);
 });
 
-asyncTest("mdast linting", function() {
+asyncTest("remark linting", function() {
   var redis = Redis.createClient();
   var houndJavascript = new HoundJavascript(redis);
   var linter = new Linter(houndJavascript);
@@ -75,7 +75,7 @@ asyncTest("Reporting an invalid configuration file", function() {
         {
           commit_sha: "commit_sha",
           pull_request_number: "pull_request_number",
-          linter_name: "mdast",
+          linter_name: "remark",
         },
         "pushes a job onto the queue"
       );


### PR DESCRIPTION
Does not include changes for renamed repo or Heroku apps, since they
have not been renamed yet.

I think this will resolve #5 and we can rename the repo and Heroku apps after-the-fact.

https://trello.com/c/vFLTg8IQ